### PR TITLE
Omit Content-Type header

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "es6-promise": "^4.1.0",
     "lodash.isstring": "^4.0.1",
     "lodash.merge": "^4.6.0",
+    "lodash.omit": "^4.5.0",
     "lodash.pickby": "^4.6.0",
     "qs": "^6.4.0",
     "whatwg-fetch": "^2.0.3"

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import 'es6-promise/auto';
 import 'whatwg-fetch';
 import qs from 'qs';
+import omit from 'lodash.omit';
 import merge from 'lodash.merge';
 import pickBy from 'lodash.pickby';
 import isString from 'lodash.isstring';
@@ -38,6 +39,11 @@ function requestBody(body, headers) {
 
 function request(payload) {
   const { url, query, ...options } = merge({}, DEFAULT_PAYLOAD, payload);
+
+  if (options.headers['Content-Type'] === false) {
+    options.headers = omit(options.headers, 'Content-Type');
+  }
+
   const { body, headers } = options;
   const urlWithQueryParams = url + filteredParams(query);
   const fetchOptions = merge({}, options, { body: requestBody(body, headers) });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -59,6 +59,31 @@ describe('jFetch', () => {
       expect(mock.called()).toBeTruthy();
     });
 
+    it('calls fetch without Content-Type if Content-Type header has set to false', () => {
+      const mock = fetchMock.mock(
+        '/some_url',
+        {
+          headers: {
+            'X-My-Header': 123,
+            'Accept': 'application/json'
+          },
+          ...options
+        }
+      );
+
+      httpFunction({
+        url: '/some_url',
+        headers: {
+          'X-My-Header': 123,
+          'Accept': 'application/json',
+          'Content-Type': false
+        },
+        ...options
+      });
+
+      expect(mock.called()).toBeTruthy();
+    });
+
     it('returns resolved promise if success callback is not passed', () => {
       fetchMock.mock(
         '/some_url',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2385,6 +2385,10 @@ lodash.merge@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
 
+lodash.omit@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.omit/-/lodash.omit-4.5.0.tgz#6eb19ae5a1ee1dd9df0b969e66ce0b7fa30b5e60"
+
 lodash.pickby@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash.pickby/-/lodash.pickby-4.6.0.tgz#7dea21d8c18d7703a27c704c15d3b84a67e33aff"


### PR DESCRIPTION
As in jQuery [ajax](http://api.jquery.com/jquery.ajax/) we should have ability to set `Content-Type` header to `false` to avoid problems with sending files. It allows to browser generate appropriate Content-Type automatically.